### PR TITLE
Fix log4j error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y openjdk-6-jre git && \
     git clone https://github.com/cobbzilla/s3s3mirror.git /opt/s3s3mirror
+    
+WORKDIR /opt/s3s3mirror
 
-ENTRYPOINT ["/opt/s3s3mirror/s3s3mirror.sh"]
+ENTRYPOINT ["s3s3mirror.sh"]


### PR DESCRIPTION
currently you get this:

Status: Downloaded newer image for pmoust/s3s3mirror:latest
log4j:ERROR Could not parse url [file:target/conf/log4j.xml].
java.io.FileNotFoundException: target/conf/log4j.xml (No such file or directory)

this is because the s3s3mirror.sh script is using a relative path to find the log4j config
if you make the checked out repo the working directory in the docker file then this problem goes away and output logs properly
